### PR TITLE
feat: add `actionFn` to ctx

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -7,11 +7,18 @@ import type {
 
 export type { LoadingState, LoadingItemState };
 
+type IfAny<T, Y, N> = 0 extends 1 & T ? Y : N;
+
 export interface PipeCtx<P = any> {
   name: string;
   key: string;
   payload: P;
   action: ActionWithPayload<CreateActionPayload<P>>;
+  actionFn: IfAny<
+    P,
+    CreateAction<PipeCtx>,
+    CreateActionWithPayload<PipeCtx<P>, P>
+  >;
 }
 
 export interface ApiFetchSuccess<S = any> {


### PR DESCRIPTION
This feature allows the user to call the original action creator for the endpoint.  This provides some unique abilities to "call the same endpoint but with different parameters."

This feature should be used with caution because if the user doesn't guard against running `actionFn` they could get stuck in an infinite loop.

For example:

```ts
const api = createApi();
api.use(api.routes());
const fetchApps = api.get('/apps', function* (ctx, next) {
    yield put(ctx.actionFn()); // this causes an infinite loop
})
```