### PR TITLE
custom key and hash key

### DIFF
--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -72,7 +72,7 @@ test('createApi - POST', async (t) => {
   const reducers = createReducerMap(cache);
   const store = setupStore(query.saga(), reducers);
   store.dispatch(createUser({ email: mockUser.email }));
-  await sleep(50);
+  await await sleep(150);
   t.deepEqual(store.getState().users, {
     '1': { id: '1', name: 'test', email: 'test@test.com' },
   });
@@ -231,7 +231,7 @@ test('createApi with hash key on a large post', async (t) => {
   const reducers = createReducerMap();
   const store = setupStore(query.saga(), reducers);
   store.dispatch(createUserDefaultKey({ email, largetext }));
-  await sleep(50);
+  await await sleep(150);
   const s = await store.getState();
   const expectedKey = createKey('/users [POST]', { email, largetext });
 

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -7,9 +7,9 @@ import { Buffer } from 'buffer';
 
 import { urlParser, queryCtx, requestMonitor } from './middleware';
 import { createApi } from './api';
-import { setupStore } from './util';
+import { setupStore, sleep } from './util';
 import { createKey } from './create-key';
-import { ApiCtx } from '.';
+import type { ApiCtx } from './types';
 
 interface User {
   id: string;
@@ -23,12 +23,6 @@ const jsonBlob = (data: any) => {
   return Buffer.from(JSON.stringify(data));
 };
 
-const sleep = (n: number) =>
-  new Promise<void>((resolve) => {
-    setTimeout(() => {
-      resolve();
-    }, n);
-  });
 test('createApi - POST', async (t) => {
   t.plan(2);
   const name = 'users';
@@ -78,7 +72,7 @@ test('createApi - POST', async (t) => {
   const reducers = createReducerMap(cache);
   const store = setupStore(query.saga(), reducers);
   store.dispatch(createUser({ email: mockUser.email }));
-  await sleep(150);
+  await sleep(10);
   t.deepEqual(store.getState().users, {
     '1': { id: '1', name: 'test', email: 'test@test.com' },
   });

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -72,7 +72,7 @@ test('createApi - POST', async (t) => {
   const reducers = createReducerMap(cache);
   const store = setupStore(query.saga(), reducers);
   store.dispatch(createUser({ email: mockUser.email }));
-  await sleep(10);
+  await sleep(50);
   t.deepEqual(store.getState().users, {
     '1': { id: '1', name: 'test', email: 'test@test.com' },
   });
@@ -231,7 +231,7 @@ test('createApi with hash key on a large post', async (t) => {
   const reducers = createReducerMap();
   const store = setupStore(query.saga(), reducers);
   store.dispatch(createUserDefaultKey({ email, largetext }));
-  await sleep(150);
+  await sleep(50);
   const s = await store.getState();
   const expectedKey = createKey('/users [POST]', { email, largetext });
 

--- a/src/create-key.ts
+++ b/src/create-key.ts
@@ -1,5 +1,4 @@
 import { isObject } from './util';
-import { encodeBase64 } from './encoding';
 
 const deepSortObject = (opts?: any): any => {
   if (!isObject(opts)) return opts;
@@ -14,12 +13,24 @@ const deepSortObject = (opts?: any): any => {
     }, {});
 };
 
+function padStart(hash: string, len: number) {
+  while (hash.length < len) {
+    hash = '0' + hash;
+  }
+  return hash;
+}
+
+const tinySimpleHash = (s: string) => {
+  for (var i = 0, h = 9; i < s.length; )
+    h = Math.imul(h ^ s.charCodeAt(i++), 9 ** 9);
+  return h ^ (h >>> 9);
+};
+
 export const createKey = (name: string, payload?: any) => {
-  const enc =
-    typeof payload !== undefined
-      ? encodeBase64(JSON.stringify(deepSortObject(payload)))
-      : '';
-  const encKey = enc ? `|${enc}` : '';
-  const key = `${name}${encKey}`;
-  return key;
+  const normJsonString =
+    typeof payload !== undefined ? JSON.stringify(deepSortObject(payload)) : '';
+  const hash = normJsonString
+    ? padStart(tinySimpleHash(normJsonString).toString(16), 8)
+    : '';
+  return hash ? `${name}|${hash}` : name;
 };

--- a/src/create-key.ts
+++ b/src/create-key.ts
@@ -19,7 +19,7 @@ function padStart(hash: string, len: number) {
   }
   return hash;
 }
-
+//credit to Ivan Perelivskiy: https://gist.github.com/iperelivskiy/4110988
 const tinySimpleHash = (s: string) => {
   for (var i = 0, h = 9; i < s.length; )
     h = Math.imul(h ^ s.charCodeAt(i++), 9 ** 9);

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -419,9 +419,9 @@ test('createApi with own key', async (t) => {
   const reducers = createReducerMap();
   const store = setupStore(query.saga(), reducers);
   store.dispatch(createUserCustomKey({ email: newUEmail }));
-  await sleep(10);
+  await sleep(50);
   const s = await store.getState();
-  await sleep(10);
+  await sleep(50);
   const expectedKey = theTestKey
     ? `/users [POST]|${theTestKey}`
     : createKey('/users [POST]', { email: newUEmail });
@@ -477,9 +477,9 @@ test('createApi with custom key but no payload', async (t) => {
   const reducers = createReducerMap();
   const store = setupStore(query.saga(), reducers);
   store.dispatch(getUsers());
-  await sleep(10);
+  await sleep(50);
   const s = await store.getState();
-  await sleep(10);
+  await sleep(50);
   const expectedKey = theTestKey
     ? `/users [GET]|${theTestKey}`
     : createKey('/users [GET]', null);

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -419,9 +419,9 @@ test('createApi with own key', async (t) => {
   const reducers = createReducerMap();
   const store = setupStore(query.saga(), reducers);
   store.dispatch(createUserCustomKey({ email: newUEmail }));
-  await sleep(50);
+  await await sleep(150);
   const s = await store.getState();
-  await sleep(50);
+  await await sleep(150);
   const expectedKey = theTestKey
     ? `/users [POST]|${theTestKey}`
     : createKey('/users [POST]', { email: newUEmail });
@@ -477,9 +477,9 @@ test('createApi with custom key but no payload', async (t) => {
   const reducers = createReducerMap();
   const store = setupStore(query.saga(), reducers);
   store.dispatch(getUsers());
-  await sleep(50);
+  await await sleep(150);
   const s = await store.getState();
-  await sleep(50);
+  await await sleep(150);
   const expectedKey = theTestKey
     ? `/users [GET]|${theTestKey}`
     : createKey('/users [GET]', null);

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -15,7 +15,7 @@ import {
 } from './middleware';
 import type { UndoCtx } from './middleware';
 import type { ApiCtx } from './types';
-import { setupStore } from './util';
+import { setupStore, sleep } from './util';
 import { createKey } from './create-key';
 import { DATA_NAME, LOADERS_NAME, createQueryState } from './slice';
 import { SagaIterator } from 'redux-saga';
@@ -36,13 +36,6 @@ function* latest(action: string, saga: any, ...args: any[]) {
 const jsonBlob = (data: any) => {
   return Buffer.from(JSON.stringify(data));
 };
-
-const sleep = (n: number) =>
-  new Promise<void>((resolve) => {
-    setTimeout(() => {
-      resolve();
-    }, n);
-  });
 
 test('middleware - basic', (t) => {
   const name = 'users';
@@ -426,9 +419,9 @@ test('createApi with own key', async (t) => {
   const reducers = createReducerMap();
   const store = setupStore(query.saga(), reducers);
   store.dispatch(createUserCustomKey({ email: newUEmail }));
-  await sleep(150);
+  await sleep(10);
   const s = await store.getState();
-  await sleep(150);
+  await sleep(10);
   const expectedKey = theTestKey
     ? `/users [POST]|${theTestKey}`
     : createKey('/users [POST]', { email: newUEmail });
@@ -484,9 +477,9 @@ test('createApi with custom key but no payload', async (t) => {
   const reducers = createReducerMap();
   const store = setupStore(query.saga(), reducers);
   store.dispatch(getUsers());
-  await sleep(150);
+  await sleep(10);
   const s = await store.getState();
-  await sleep(150);
+  await sleep(10);
   const expectedKey = theTestKey
     ? `/users [GET]|${theTestKey}`
     : createKey('/users [GET]', null);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -264,6 +264,19 @@ export function* simpleCache<Ctx extends ApiCtx = ApiCtx>(
   ctx.actions.push(addData({ [key]: data }));
 }
 
+export function* customKey<Ctx extends ApiCtx = ApiCtx>(ctx: Ctx, next: Next) {
+  if (
+    ctx?.key &&
+    ctx?.action?.payload?.key &&
+    ctx.key !== ctx.action.payload.key
+  ) {
+    const newKey = ctx.name.split('|')[0] + '|' + ctx.key;
+    ctx.key = newKey;
+    ctx.action.payload.key = newKey;
+  }
+  yield next();
+}
+
 export function requestMonitor<Ctx extends ApiCtx = ApiCtx>(
   errorFn?: (ctx: Ctx) => string,
 ) {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -287,6 +287,7 @@ export function requestMonitor<Ctx extends ApiCtx = ApiCtx>(
     dispatchActions,
     loadingMonitor(errorFn),
     simpleCache,
+    customKey,
   ]);
 }
 

--- a/src/pipe.test.ts
+++ b/src/pipe.test.ts
@@ -341,7 +341,7 @@ test('middleware order of execution', async (t) => {
   const store = setupStore(api.saga());
   store.dispatch(action());
 
-  await sleep(50);
+  await await sleep(150);
   t.assert(acc === 'abcdefg');
 });
 
@@ -367,7 +367,7 @@ test('retry with actionFn', async (t) => {
   const store = setupStore(api.saga());
   store.dispatch(action());
 
-  await sleep(50);
+  await await sleep(150);
   t.deepEqual(acc, 'agag');
 });
 
@@ -393,6 +393,6 @@ test('retry with actionFn with payload', async (t) => {
   const store = setupStore(api.saga());
   store.dispatch(action({ page: 1 }));
 
-  await sleep(50);
+  await await sleep(150);
   t.deepEqual(acc, 'aagg');
 });

--- a/src/pipe.test.ts
+++ b/src/pipe.test.ts
@@ -341,7 +341,7 @@ test('middleware order of execution', async (t) => {
   const store = setupStore(api.saga());
   store.dispatch(action());
 
-  await sleep(10);
+  await sleep(50);
   t.assert(acc === 'abcdefg');
 });
 
@@ -367,7 +367,7 @@ test('retry with actionFn', async (t) => {
   const store = setupStore(api.saga());
   store.dispatch(action());
 
-  await sleep(10);
+  await sleep(50);
   t.deepEqual(acc, 'agag');
 });
 
@@ -393,6 +393,6 @@ test('retry with actionFn with payload', async (t) => {
   const store = setupStore(api.saga());
   store.dispatch(action({ page: 1 }));
 
-  await sleep(10);
+  await sleep(50);
   t.deepEqual(acc, 'aagg');
 });

--- a/src/pipe.test.ts
+++ b/src/pipe.test.ts
@@ -6,7 +6,7 @@ import type { Action, MapEntity } from 'robodux';
 
 import { createPipe } from './pipe';
 import type { PipeCtx, Next } from './types';
-import { setupStore as prepStore } from './util';
+import { setupStore as prepStore, sleep } from './util';
 import { createQueryState } from './slice';
 
 interface RoboCtx<D = any, P = any> extends PipeCtx<P> {
@@ -310,13 +310,6 @@ test('run() on endpoint action - should run the effect', (t) => {
   store.dispatch(action2());
 });
 
-const sleep = (n: number) =>
-  new Promise<void>((resolve) => {
-    setTimeout(() => {
-      resolve();
-    }, n);
-  });
-
 test('middleware order of execution', async (t) => {
   t.plan(1);
   let acc = '';
@@ -348,7 +341,7 @@ test('middleware order of execution', async (t) => {
   const store = setupStore(api.saga());
   store.dispatch(action());
 
-  await sleep(150);
+  await sleep(10);
   t.assert(acc === 'abcdefg');
 });
 
@@ -374,7 +367,7 @@ test('retry with actionFn', async (t) => {
   const store = setupStore(api.saga());
   store.dispatch(action());
 
-  await sleep(150);
+  await sleep(10);
   t.deepEqual(acc, 'agag');
 });
 
@@ -400,6 +393,6 @@ test('retry with actionFn with payload', async (t) => {
   const store = setupStore(api.saga());
   store.dispatch(action({ page: 1 }));
 
-  await sleep(150);
+  await sleep(10);
   t.deepEqual(acc, 'aagg');
 });

--- a/src/react.test.ts
+++ b/src/react.test.ts
@@ -90,8 +90,8 @@ test('useApi - with action creator', async (t) => {
   const App = () => {
     const query = useApi(fetchUser);
     const user = useSelector((s: any) => {
-      const cacheKey = createKey('/user/:id [GET]', { id: '1' });
-      return s['@@saga-query/data'][cacheKey];
+      const id = createKey(`${fetchUser}`, { id: '1' });
+      return selectDataById(s, { id });
     });
     return h('div', null, [
       h('div', { key: '1' }, user?.email || 'no user'),

--- a/src/react.test.ts
+++ b/src/react.test.ts
@@ -11,6 +11,7 @@ import { setupStore } from './util';
 import { useApi } from './react';
 import { delay } from 'redux-saga/effects';
 import { selectDataById } from './slice';
+import { createKey } from './create-key';
 import { createAssign } from 'robodux';
 
 (global as any).IS_REACT_ACT_ENVIRONMENT = true;
@@ -88,10 +89,12 @@ test('useApi - with action creator', async (t) => {
   const { fetchUser, store } = setupTest();
   const App = () => {
     const query = useApi(fetchUser);
-    const user = useSelector((s: any) => s.user);
-
+    const user = useSelector((s: any) => {
+      const cacheKey = createKey('/user/:id [GET]', { id: '1' });
+      return s['@@saga-query/data'][cacheKey];
+    });
     return h('div', null, [
-      h('div', { key: '1' }, user?.email || ''),
+      h('div', { key: '1' }, user?.email || 'no user'),
       h(
         'button',
         { key: '2', onClick: () => query.trigger({ id: '1' }) },

--- a/src/util.ts
+++ b/src/util.ts
@@ -57,3 +57,10 @@ export const mergeRequest = (
     headers: mergeHeaders((cur as any).headers, (next as any).headers),
   };
 };
+
+export const sleep = (n: number) =>
+  new Promise<void>((resolve) => {
+    setTimeout(() => {
+      resolve();
+    }, n);
+  });


### PR DESCRIPTION
This PR adresses two distinct issues

### 1. The user will have the ability to define a **custom key**
 There are cases when the saga-query key is needed in dev functions, in order to distinguish between similar requests and differentiate the datasets. In other cases is useful when operating directly with cached datasets and there is a need for customize the cache store selectors. Also in some custom caching middleware or used as a marker in  the request to the backend. 
Overall it is important to give the developer the freedom to operate.

If the custom key is provided then it will be used. Otherwise the default one will be applied.
The usage of the custom key:
```js
const query = createApi();
  query.use(requestMonitor());
  query.use(query.routes());
  query.use(customKey);
 //...

const createUserCustomKey = query.post<{ email: string }>(
    `/users`,
    function* processUsers(ctx: ApiCtx<any, any>, next) {
      ctx.cache = true;
      ctx.key = 'MY_CUSTOM_KEY'; 
      yield next();
     //...
    },
  );
````
Alternatively  the customKey middleware can be set as default inside the ```requestMonitor``` middleware, similar with  the ```simpleCache``` middleware. In such case the developer should not care to include the middleware in the api definition. The simple definition of the key being enough to override the default key.

### 2. In the absence of a custom defined  key, saga-query will create **default hash key**.  
 This feature replaces the existing base64 key with a hashed one. The main reason for this feature is the case of large fetch query parameters.  When base64 encoded this will generate a large key in the store.

Having both features available, the developer can choose between implementing its 'own keys, when more fine tuning in needed, or letting the saga-query to create the key.
