### PR TITLE
feat: support multiple endpoints with the same name

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -10,6 +10,8 @@ import type {
 import { createPipe } from './pipe';
 import type { SagaApi } from './pipe';
 
+type ApiName = string | string[];
+
 export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
   extends SagaApi<Ctx> {
   request: (
@@ -109,176 +111,185 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
     ): CreateActionWithPayload<Ctx, P>;
   };
 
-  get(name: string): CreateAction<Ctx>;
-  get<P>(name: string): CreateActionWithPayload<Ctx, P>;
-  get(name: string, req: { saga?: any }): CreateAction<Ctx>;
-  get<P>(name: string, req: { saga?: any }): CreateActionWithPayload<Ctx, P>;
-  get(name: string, fn: MiddlewareCo<Ctx>): CreateAction<Ctx>;
-  get<P>(name: string, fn: MiddlewareCo<Ctx>): CreateActionWithPayload<Ctx, P>;
+  get(name: ApiName): CreateAction<Ctx>;
+  get<P>(name: ApiName): CreateActionWithPayload<Ctx, P>;
+  get(name: ApiName, req: { saga?: any }): CreateAction<Ctx>;
+  get<P>(name: ApiName, req: { saga?: any }): CreateActionWithPayload<Ctx, P>;
+  get(name: ApiName, fn: MiddlewareCo<Ctx>): CreateAction<Ctx>;
+  get<P>(name: ApiName, fn: MiddlewareCo<Ctx>): CreateActionWithPayload<Ctx, P>;
   get(
-    name: string,
+    name: ApiName,
     req: { saga?: any },
     fn: MiddlewareCo<Ctx>,
   ): CreateAction<Ctx>;
   get<P>(
-    name: string,
+    name: ApiName,
     req: { saga?: any },
     fn: MiddlewareCo<Ctx>,
   ): CreateActionWithPayload<Ctx, P>;
 
-  post(name: string): CreateAction<Ctx>;
-  post<P>(name: string): CreateActionWithPayload<Ctx, P>;
-  post(name: string, req: { saga?: any }): CreateAction<Ctx>;
-  post<P>(name: string, req: { saga?: any }): CreateActionWithPayload<Ctx, P>;
-  post(name: string, fn: MiddlewareCo<Ctx>): CreateAction<Ctx>;
-  post<P>(name: string, fn: MiddlewareCo<Ctx>): CreateActionWithPayload<Ctx, P>;
+  post(name: ApiName): CreateAction<Ctx>;
+  post<P>(name: ApiName): CreateActionWithPayload<Ctx, P>;
+  post(name: ApiName, req: { saga?: any }): CreateAction<Ctx>;
+  post<P>(name: ApiName, req: { saga?: any }): CreateActionWithPayload<Ctx, P>;
+  post(name: ApiName, fn: MiddlewareCo<Ctx>): CreateAction<Ctx>;
+  post<P>(
+    name: ApiName,
+    fn: MiddlewareCo<Ctx>,
+  ): CreateActionWithPayload<Ctx, P>;
   post(
-    name: string,
+    name: ApiName,
     req: { saga?: any },
     fn: MiddlewareCo<Ctx>,
   ): CreateAction<Ctx>;
   post<P>(
-    name: string,
+    name: ApiName,
     req: { saga?: any },
     fn: MiddlewareCo<Ctx>,
   ): CreateActionWithPayload<Ctx, P>;
 
-  put(name: string): CreateAction<Ctx>;
-  put<P>(name: string): CreateActionWithPayload<Ctx, P>;
-  put(name: string, req: { saga?: any }): CreateAction<Ctx>;
-  put<P>(name: string, req: { saga?: any }): CreateActionWithPayload<Ctx, P>;
-  put(name: string, fn: MiddlewareCo<Ctx>): CreateAction<Ctx>;
-  put<P>(name: string, fn: MiddlewareCo<Ctx>): CreateActionWithPayload<Ctx, P>;
+  put(name: ApiName): CreateAction<Ctx>;
+  put<P>(name: ApiName): CreateActionWithPayload<Ctx, P>;
+  put(name: ApiName, req: { saga?: any }): CreateAction<Ctx>;
+  put<P>(name: ApiName, req: { saga?: any }): CreateActionWithPayload<Ctx, P>;
+  put(name: ApiName, fn: MiddlewareCo<Ctx>): CreateAction<Ctx>;
+  put<P>(name: ApiName, fn: MiddlewareCo<Ctx>): CreateActionWithPayload<Ctx, P>;
   put(
-    name: string,
+    name: ApiName,
     req: { saga?: any },
     fn: MiddlewareCo<Ctx>,
   ): CreateAction<Ctx>;
   put<P>(
-    name: string,
+    name: ApiName,
     req: { saga?: any },
     fn: MiddlewareCo<Ctx>,
   ): CreateActionWithPayload<Ctx, P>;
 
-  patch(name: string): CreateAction<Ctx>;
-  patch<P>(name: string): CreateActionWithPayload<Ctx, P>;
-  patch(name: string, req: { saga?: any }): CreateAction<Ctx>;
-  patch<P>(name: string, req: { saga?: any }): CreateActionWithPayload<Ctx, P>;
-  patch(name: string, fn: MiddlewareCo<Ctx>): CreateAction<Ctx>;
+  patch(name: ApiName): CreateAction<Ctx>;
+  patch<P>(name: ApiName): CreateActionWithPayload<Ctx, P>;
+  patch(name: ApiName, req: { saga?: any }): CreateAction<Ctx>;
+  patch<P>(name: ApiName, req: { saga?: any }): CreateActionWithPayload<Ctx, P>;
+  patch(name: ApiName, fn: MiddlewareCo<Ctx>): CreateAction<Ctx>;
   patch<P>(
-    name: string,
+    name: ApiName,
     fn: MiddlewareCo<Ctx>,
   ): CreateActionWithPayload<Ctx, P>;
   patch(
-    name: string,
+    name: ApiName,
     req: { saga?: any },
     fn: MiddlewareCo<Ctx>,
   ): CreateAction<Ctx>;
   patch<P>(
-    name: string,
+    name: ApiName,
     req: { saga?: any },
     fn: MiddlewareCo<Ctx>,
   ): CreateActionWithPayload<Ctx, P>;
 
-  delete(name: string): CreateAction<Ctx>;
-  delete<P>(name: string): CreateActionWithPayload<Ctx, P>;
-  delete(name: string, req: { saga?: any }): CreateAction<Ctx>;
-  delete<P>(name: string, req: { saga?: any }): CreateActionWithPayload<Ctx, P>;
-  delete(name: string, fn: MiddlewareCo<Ctx>): CreateAction<Ctx>;
+  delete(name: ApiName): CreateAction<Ctx>;
+  delete<P>(name: ApiName): CreateActionWithPayload<Ctx, P>;
+  delete(name: ApiName, req: { saga?: any }): CreateAction<Ctx>;
   delete<P>(
-    name: string,
+    name: ApiName,
+    req: { saga?: any },
+  ): CreateActionWithPayload<Ctx, P>;
+  delete(name: ApiName, fn: MiddlewareCo<Ctx>): CreateAction<Ctx>;
+  delete<P>(
+    name: ApiName,
     fn: MiddlewareCo<Ctx>,
   ): CreateActionWithPayload<Ctx, P>;
   delete(
-    name: string,
+    name: ApiName,
     req: { saga?: any },
     fn: MiddlewareCo<Ctx>,
   ): CreateAction<Ctx>;
   delete<P>(
-    name: string,
+    name: ApiName,
     req: { saga?: any },
     fn: MiddlewareCo<Ctx>,
   ): CreateActionWithPayload<Ctx, P>;
 
-  options(name: string): CreateAction<Ctx>;
-  options<P>(name: string): CreateActionWithPayload<Ctx, P>;
-  options(name: string, req: { saga?: any }): CreateAction<Ctx>;
+  options(name: ApiName): CreateAction<Ctx>;
+  options<P>(name: ApiName): CreateActionWithPayload<Ctx, P>;
+  options(name: ApiName, req: { saga?: any }): CreateAction<Ctx>;
   options<P>(
-    name: string,
+    name: ApiName,
     req: { saga?: any },
   ): CreateActionWithPayload<Ctx, P>;
-  options(name: string, fn: MiddlewareCo<Ctx>): CreateAction<Ctx>;
+  options(name: ApiName, fn: MiddlewareCo<Ctx>): CreateAction<Ctx>;
   options<P>(
-    name: string,
+    name: ApiName,
     fn: MiddlewareCo<Ctx>,
   ): CreateActionWithPayload<Ctx, P>;
   options(
-    name: string,
+    name: ApiName,
     req: { saga?: any },
     fn: MiddlewareCo<Ctx>,
   ): CreateAction<Ctx>;
   options<P>(
-    name: string,
+    name: ApiName,
     req: { saga?: any },
     fn: MiddlewareCo<Ctx>,
   ): CreateActionWithPayload<Ctx, P>;
 
-  head(name: string): CreateAction<Ctx>;
-  head<P>(name: string): CreateActionWithPayload<Ctx, P>;
-  head(name: string, req: { saga?: any }): CreateAction<Ctx>;
-  head<P>(name: string, req: { saga?: any }): CreateActionWithPayload<Ctx, P>;
-  head(name: string, fn: MiddlewareCo<Ctx>): CreateAction<Ctx>;
-  head<P>(name: string, fn: MiddlewareCo<Ctx>): CreateActionWithPayload<Ctx, P>;
+  head(name: ApiName): CreateAction<Ctx>;
+  head<P>(name: ApiName): CreateActionWithPayload<Ctx, P>;
+  head(name: ApiName, req: { saga?: any }): CreateAction<Ctx>;
+  head<P>(name: ApiName, req: { saga?: any }): CreateActionWithPayload<Ctx, P>;
+  head(name: ApiName, fn: MiddlewareCo<Ctx>): CreateAction<Ctx>;
+  head<P>(
+    name: ApiName,
+    fn: MiddlewareCo<Ctx>,
+  ): CreateActionWithPayload<Ctx, P>;
   head(
-    name: string,
+    name: ApiName,
     req: { saga?: any },
     fn: MiddlewareCo<Ctx>,
   ): CreateAction<Ctx>;
   head<P>(
-    name: string,
+    name: ApiName,
     req: { saga?: any },
     fn: MiddlewareCo<Ctx>,
   ): CreateActionWithPayload<Ctx, P>;
 
-  connect(name: string): CreateAction<Ctx>;
-  connect<P>(name: string): CreateActionWithPayload<Ctx, P>;
-  connect(name: string, req: { saga?: any }): CreateAction<Ctx>;
+  connect(name: ApiName): CreateAction<Ctx>;
+  connect<P>(name: ApiName): CreateActionWithPayload<Ctx, P>;
+  connect(name: ApiName, req: { saga?: any }): CreateAction<Ctx>;
   connect<P>(
-    name: string,
+    name: ApiName,
     req: { saga?: any },
   ): CreateActionWithPayload<Ctx, P>;
-  connect(name: string, fn: MiddlewareCo<Ctx>): CreateAction<Ctx>;
+  connect(name: ApiName, fn: MiddlewareCo<Ctx>): CreateAction<Ctx>;
   connect<P>(
-    name: string,
+    name: ApiName,
     fn: MiddlewareCo<Ctx>,
   ): CreateActionWithPayload<Ctx, P>;
   connect(
-    name: string,
+    name: ApiName,
     req: { saga?: any },
     fn: MiddlewareCo<Ctx>,
   ): CreateAction<Ctx>;
   connect<P>(
-    name: string,
+    name: ApiName,
     req: { saga?: any },
     fn: MiddlewareCo<Ctx>,
   ): CreateActionWithPayload<Ctx, P>;
 
-  trace(name: string): CreateAction<Ctx>;
-  trace<P>(name: string): CreateActionWithPayload<Ctx, P>;
-  trace(name: string, req: { saga?: any }): CreateAction<Ctx>;
-  trace<P>(name: string, req: { saga?: any }): CreateActionWithPayload<Ctx, P>;
-  trace(name: string, fn: MiddlewareCo<Ctx>): CreateAction<Ctx>;
+  trace(name: ApiName): CreateAction<Ctx>;
+  trace<P>(name: ApiName): CreateActionWithPayload<Ctx, P>;
+  trace(name: ApiName, req: { saga?: any }): CreateAction<Ctx>;
+  trace<P>(name: ApiName, req: { saga?: any }): CreateActionWithPayload<Ctx, P>;
+  trace(name: ApiName, fn: MiddlewareCo<Ctx>): CreateAction<Ctx>;
   trace<P>(
-    name: string,
+    name: ApiName,
     fn: MiddlewareCo<Ctx>,
   ): CreateActionWithPayload<Ctx, P>;
   trace(
-    name: string,
+    name: ApiName,
     req: { saga?: any },
     fn: MiddlewareCo<Ctx>,
   ): CreateAction<Ctx>;
   trace<P>(
-    name: string,
+    name: ApiName,
     req: { saga?: any },
     fn: MiddlewareCo<Ctx>,
   ): CreateActionWithPayload<Ctx, P>;
@@ -310,18 +321,35 @@ export function createApi<Ctx extends ApiCtx = ApiCtx>(
   basePipe?: SagaApi<Ctx>,
 ): SagaQueryApi<Ctx> {
   const pipe = basePipe || createPipe<Ctx>();
-  const uri = (name: string) => {
+  const uri = (prename: ApiName) => {
     const create = pipe.create as any;
+
+    let name = prename;
+    let remainder = '';
+    if (Array.isArray(name)) {
+      if (name.length === 0) {
+        throw new Error(
+          'createApi requires a non-empty array for the name of the endpoint',
+        );
+      }
+      name = prename[0];
+      if (name.length > 1) {
+        const [_, ...other] = prename;
+        remainder = ` ${other.join('|')}`;
+      }
+    }
+    const tmpl = (method: string) => `${name} [${method}]${remainder}`;
+
     return {
-      get: (...args: any[]) => create(`${name} [GET]`, ...args),
-      post: (...args: any[]) => create(`${name} [POST]`, ...args),
-      put: (...args: any[]) => create(`${name} [PUT]`, ...args),
-      patch: (...args: any[]) => create(`${name} [PATCH]`, ...args),
-      delete: (...args: any[]) => create(`${name} [DELETE]`, ...args),
-      options: (...args: any[]) => create(`${name} [OPTIONS]`, ...args),
-      head: (...args: any[]) => create(`${name} [HEAD]`, ...args),
-      connect: (...args: any[]) => create(`${name} [CONNECT]`, ...args),
-      trace: (...args: any[]) => create(`${name} [TRACE]`, ...args),
+      get: (...args: any[]) => create(tmpl('GET'), ...args),
+      post: (...args: any[]) => create(tmpl('POST'), ...args),
+      put: (...args: any[]) => create(tmpl('PUT'), ...args),
+      patch: (...args: any[]) => create(tmpl('PATCH'), ...args),
+      delete: (...args: any[]) => create(tmpl('DELETE'), ...args),
+      options: (...args: any[]) => create(tmpl('OPTIONS'), ...args),
+      head: (...args: any[]) => create(tmpl('HEAD'), ...args),
+      connect: (...args: any[]) => create(tmpl('CONNECT'), ...args),
+      trace: (...args: any[]) => create(tmpl('TRACE'), ...args),
     };
   };
 
@@ -343,14 +371,14 @@ export function createApi<Ctx extends ApiCtx = ApiCtx>(
       };
     },
     uri,
-    get: (name: string, ...args: any[]) => uri(name).get(...args),
-    post: (name: string, ...args: any[]) => uri(name).post(...args),
-    put: (name: string, ...args: any[]) => uri(name).put(...args),
-    patch: (name: string, ...args: any[]) => uri(name).patch(...args),
-    delete: (name: string, ...args: any[]) => uri(name).delete(...args),
-    options: (name: string, ...args: any[]) => uri(name).options(...args),
-    head: (name: string, ...args: any[]) => uri(name).head(...args),
-    connect: (name: string, ...args: any[]) => uri(name).connect(...args),
-    trace: (name: string, ...args: any[]) => uri(name).trace(...args),
+    get: (name: ApiName, ...args: any[]) => uri(name).get(...args),
+    post: (name: ApiName, ...args: any[]) => uri(name).post(...args),
+    put: (name: ApiName, ...args: any[]) => uri(name).put(...args),
+    patch: (name: ApiName, ...args: any[]) => uri(name).patch(...args),
+    delete: (name: ApiName, ...args: any[]) => uri(name).delete(...args),
+    options: (name: ApiName, ...args: any[]) => uri(name).options(...args),
+    head: (name: ApiName, ...args: any[]) => uri(name).head(...args),
+    connect: (name: ApiName, ...args: any[]) => uri(name).connect(...args),
+    trace: (name: ApiName, ...args: any[]) => uri(name).trace(...args),
   };
 }

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -352,7 +352,7 @@ test('undo', (t) => {
     ...createQueryState({
       [LOADERS_NAME]: {
         [`${createUser}`]: defaultLoadingItem(),
-        [action.payload.key]: defaultLoadingItem(),
+        [action.payload.name]: defaultLoadingItem(),
       },
     }),
   });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -85,7 +85,7 @@ export function* urlParser<Ctx extends ApiCtx = ApiCtx>(ctx: Ctx, next: Next) {
 
   let method = '';
   httpMethods.forEach((curMethod) => {
-    const pattern = new RegExp(`\\s*\\[` + curMethod + `\\]\\s*`, 'i');
+    const pattern = new RegExp(`\\s*\\[` + curMethod + `\\]\\s*\\w*`, 'i');
     const tmpUrl = url.replace(pattern, '');
     if (tmpUrl.length !== url.length) {
       method = curMethod.toLocaleUpperCase();

--- a/src/pipe.test.ts
+++ b/src/pipe.test.ts
@@ -295,7 +295,7 @@ test('run() on endpoint action - should run the effect', (t) => {
       t.assert(acc === 'ab');
       t.like(curCtx, {
         action: {
-          type: '@@saga-query/users',
+          type: `@@saga-query${action1}`,
           payload: {
             name: '/users',
           },
@@ -341,7 +341,7 @@ test('middleware order of execution', async (t) => {
   const store = setupStore(api.saga());
   store.dispatch(action());
 
-  await await sleep(150);
+  await sleep(150);
   t.assert(acc === 'abcdefg');
 });
 
@@ -367,7 +367,7 @@ test('retry with actionFn', async (t) => {
   const store = setupStore(api.saga());
   store.dispatch(action());
 
-  await await sleep(150);
+  await sleep(150);
   t.deepEqual(acc, 'agag');
 });
 
@@ -393,6 +393,6 @@ test('retry with actionFn with payload', async (t) => {
   const store = setupStore(api.saga());
   store.dispatch(action({ page: 1 }));
 
-  await await sleep(150);
+  await sleep(150);
   t.deepEqual(acc, 'aagg');
 });


### PR DESCRIPTION
Previously the name provieded to `api.get('/the-name')` had to be unique.

Internally we used that name for a few internal maps that assumed they would always be unique.

However, we want to support the ability for `createApi` to support scenariors where you have the same name HTTP endpoint defined multiple times.  Why would someone want that?  Because we have special sagas that can be used to provide additional functionality to our endpoints -- like polling -- we want to ensure they can use them without colliding with more basic endpoints.

```ts
const api = createApi();
const action = api.get('/');
const pollAction = api.get('/', { saga: poll(5 * 1000) });

dispatch(pollAction());
dispatch(action());
```

Here we have a case where we want to duplicate
the name because it relates to the API endpoint we want to hit.

To fix this we now support the ability to provide an array for the name of the endpoint.

```ts
const api = createApi();
const action = api.get('/');
const pollAction = api.get(['/', 'poller'], { saga: poll(5 * 1000) });

dispatch(pollAction());
dispatch(action());
```

The first part is the string used to generate the url with our `urlParser` middleware.  The remaining parts are used for making the name unique and are otherwise not used.

Although other middleware could be creative with using the array of strings.