### PR TITLE
feat: use `typed-redux-saga` for yield delegate types

### DIFF
--- a/api-type-template.ts
+++ b/api-type-template.ts
@@ -24,6 +24,9 @@ ${method}(req: { saga?: any }): CreateAction<Ctx>;
 ${method}<P>(
   req: { saga?: any }
 ): CreateActionWithPayload<Omit<Ctx, 'payload'> & Payload<P>, P>;
+${method}<P extends never, ApiSuccess, ApiError = any>(
+  req: { saga?: any }
+): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
 ${method}<P, ApiSuccess, ApiError = any>(req: {
   saga?: any;
 }): CreateActionWithPayload<
@@ -46,6 +49,9 @@ ${method}<P>(
 ${method}<P, Gtx extends Ctx = Ctx>(
   fn: MiddlewareApiCo<Gtx>,
 ): CreateActionWithPayload<Gtx, P>;
+${method}<P extends never, ApiSuccess, ApiError = any>(
+  fn: MiddlewareApiCo<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>,
+): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
 ${method}<P, ApiSuccess, ApiError = any>(
   fn: MiddlewareApiCo<Ctx>,
 ): CreateActionWithPayload<
@@ -71,6 +77,10 @@ ${method}<P, Gtx extends Ctx = Ctx>(
   req: { saga?: any },
   fn: MiddlewareApiCo<Gtx>,
 ): CreateActionWithPayload<Gtx, P>;
+${method}<P extends never, ApiSuccess, ApiError = any>(
+  req: { saga?: any },
+  fn: MiddlewareApiCo<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>,
+): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
 ${method}<P, ApiSuccess, ApiError = any>(
   req: { saga?: any },
   fn: MiddlewareApiCo<Ctx>,
@@ -89,6 +99,9 @@ ${method}(name: ApiName): CreateAction<Ctx>;
 ${method}<P>(
   name: ApiName,
 ): CreateActionWithPayload<Omit<Ctx, 'payload'> & Payload<P>, P>;
+${method}<P extends never, ApiSuccess, ApiError = any>(
+  name: ApiName,
+): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
 ${method}<P, ApiSuccess, ApiError = any>(
   name: ApiName,
 ): CreateActionWithPayload<
@@ -110,6 +123,10 @@ ${method}<P, Gtx extends Ctx = Ctx>(
   name: ApiName,
   req: { saga?: any }
 ): CreateActionWithPayload<Gtx, P>;
+${method}<P extends never, ApiSuccess, ApiError = any>(
+  name: ApiName,
+  req: { saga?: any }
+): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
 ${method}<P, ApiSuccess, ApiError = any>(
   name: ApiName,
   req: { saga?: any },
@@ -136,6 +153,10 @@ ${method}<P, Gtx extends Ctx = Ctx>(
   name: ApiName,
   fn: MiddlewareApiCo<Gtx>,
 ): CreateActionWithPayload<Gtx, P>;
+${method}<P extends never, ApiSuccess, ApiError = any>(
+  name: ApiName,
+  fn: MiddlewareApiCo<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>,
+): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
 ${method}<P, ApiSuccess, ApiError = any>(
   name: ApiName,
   fn: MiddlewareApiCo<
@@ -173,6 +194,11 @@ ${method}<P, Gtx extends Ctx = Ctx>(
   req: { saga?: any },
   fn: MiddlewareApiCo<Gtx>,
 ): CreateActionWithPayload<Gtx, P>;
+${method}<P extends never, ApiSuccess, ApiError = any>(
+  name: ApiName,
+  req: { saga?: any },
+  fn: MiddlewareApiCo<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>,
+): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
 ${method}<P, ApiSuccess, ApiError = any>(
   name: ApiName,
   req: { saga?: any },

--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
     "redux": "^4.1.2",
     "redux-batched-actions": "^0.5.0",
     "redux-saga": "^1.1.3",
-    "robodux": "^14.0.0"
+    "robodux": "^14.0.0",
+    "typed-redux-saga": "^1.5.0"
   },
   "ava": {
     "extensions": [

--- a/src/api-types.ts
+++ b/src/api-types.ts
@@ -31,6 +31,9 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
     get<P>(req: {
       saga?: any;
     }): CreateActionWithPayload<Omit<Ctx, 'payload'> & Payload<P>, P>;
+    get<P extends never, ApiSuccess, ApiError = any>(req: {
+      saga?: any;
+    }): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
     get<P, ApiSuccess, ApiError = any>(req: {
       saga?: any;
     }): CreateActionWithPayload<
@@ -51,6 +54,9 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
     get<P, Gtx extends Ctx = Ctx>(
       fn: MiddlewareApiCo<Gtx>,
     ): CreateActionWithPayload<Gtx, P>;
+    get<P extends never, ApiSuccess, ApiError = any>(
+      fn: MiddlewareApiCo<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>,
+    ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
     get<P, ApiSuccess, ApiError = any>(
       fn: MiddlewareApiCo<Ctx>,
     ): CreateActionWithPayload<
@@ -76,6 +82,10 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
       req: { saga?: any },
       fn: MiddlewareApiCo<Gtx>,
     ): CreateActionWithPayload<Gtx, P>;
+    get<P extends never, ApiSuccess, ApiError = any>(
+      req: { saga?: any },
+      fn: MiddlewareApiCo<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>,
+    ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
     get<P, ApiSuccess, ApiError = any>(
       req: { saga?: any },
       fn: MiddlewareApiCo<Ctx>,
@@ -93,6 +103,9 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
     post<P>(req: {
       saga?: any;
     }): CreateActionWithPayload<Omit<Ctx, 'payload'> & Payload<P>, P>;
+    post<P extends never, ApiSuccess, ApiError = any>(req: {
+      saga?: any;
+    }): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
     post<P, ApiSuccess, ApiError = any>(req: {
       saga?: any;
     }): CreateActionWithPayload<
@@ -113,6 +126,9 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
     post<P, Gtx extends Ctx = Ctx>(
       fn: MiddlewareApiCo<Gtx>,
     ): CreateActionWithPayload<Gtx, P>;
+    post<P extends never, ApiSuccess, ApiError = any>(
+      fn: MiddlewareApiCo<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>,
+    ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
     post<P, ApiSuccess, ApiError = any>(
       fn: MiddlewareApiCo<Ctx>,
     ): CreateActionWithPayload<
@@ -138,6 +154,10 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
       req: { saga?: any },
       fn: MiddlewareApiCo<Gtx>,
     ): CreateActionWithPayload<Gtx, P>;
+    post<P extends never, ApiSuccess, ApiError = any>(
+      req: { saga?: any },
+      fn: MiddlewareApiCo<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>,
+    ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
     post<P, ApiSuccess, ApiError = any>(
       req: { saga?: any },
       fn: MiddlewareApiCo<Ctx>,
@@ -155,6 +175,9 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
     put<P>(req: {
       saga?: any;
     }): CreateActionWithPayload<Omit<Ctx, 'payload'> & Payload<P>, P>;
+    put<P extends never, ApiSuccess, ApiError = any>(req: {
+      saga?: any;
+    }): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
     put<P, ApiSuccess, ApiError = any>(req: {
       saga?: any;
     }): CreateActionWithPayload<
@@ -175,6 +198,9 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
     put<P, Gtx extends Ctx = Ctx>(
       fn: MiddlewareApiCo<Gtx>,
     ): CreateActionWithPayload<Gtx, P>;
+    put<P extends never, ApiSuccess, ApiError = any>(
+      fn: MiddlewareApiCo<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>,
+    ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
     put<P, ApiSuccess, ApiError = any>(
       fn: MiddlewareApiCo<Ctx>,
     ): CreateActionWithPayload<
@@ -200,6 +226,10 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
       req: { saga?: any },
       fn: MiddlewareApiCo<Gtx>,
     ): CreateActionWithPayload<Gtx, P>;
+    put<P extends never, ApiSuccess, ApiError = any>(
+      req: { saga?: any },
+      fn: MiddlewareApiCo<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>,
+    ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
     put<P, ApiSuccess, ApiError = any>(
       req: { saga?: any },
       fn: MiddlewareApiCo<Ctx>,
@@ -217,6 +247,9 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
     patch<P>(req: {
       saga?: any;
     }): CreateActionWithPayload<Omit<Ctx, 'payload'> & Payload<P>, P>;
+    patch<P extends never, ApiSuccess, ApiError = any>(req: {
+      saga?: any;
+    }): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
     patch<P, ApiSuccess, ApiError = any>(req: {
       saga?: any;
     }): CreateActionWithPayload<
@@ -237,6 +270,9 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
     patch<P, Gtx extends Ctx = Ctx>(
       fn: MiddlewareApiCo<Gtx>,
     ): CreateActionWithPayload<Gtx, P>;
+    patch<P extends never, ApiSuccess, ApiError = any>(
+      fn: MiddlewareApiCo<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>,
+    ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
     patch<P, ApiSuccess, ApiError = any>(
       fn: MiddlewareApiCo<Ctx>,
     ): CreateActionWithPayload<
@@ -262,6 +298,10 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
       req: { saga?: any },
       fn: MiddlewareApiCo<Gtx>,
     ): CreateActionWithPayload<Gtx, P>;
+    patch<P extends never, ApiSuccess, ApiError = any>(
+      req: { saga?: any },
+      fn: MiddlewareApiCo<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>,
+    ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
     patch<P, ApiSuccess, ApiError = any>(
       req: { saga?: any },
       fn: MiddlewareApiCo<Ctx>,
@@ -279,6 +319,9 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
     delete<P>(req: {
       saga?: any;
     }): CreateActionWithPayload<Omit<Ctx, 'payload'> & Payload<P>, P>;
+    delete<P extends never, ApiSuccess, ApiError = any>(req: {
+      saga?: any;
+    }): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
     delete<P, ApiSuccess, ApiError = any>(req: {
       saga?: any;
     }): CreateActionWithPayload<
@@ -299,6 +342,9 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
     delete<P, Gtx extends Ctx = Ctx>(
       fn: MiddlewareApiCo<Gtx>,
     ): CreateActionWithPayload<Gtx, P>;
+    delete<P extends never, ApiSuccess, ApiError = any>(
+      fn: MiddlewareApiCo<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>,
+    ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
     delete<P, ApiSuccess, ApiError = any>(
       fn: MiddlewareApiCo<Ctx>,
     ): CreateActionWithPayload<
@@ -324,6 +370,10 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
       req: { saga?: any },
       fn: MiddlewareApiCo<Gtx>,
     ): CreateActionWithPayload<Gtx, P>;
+    delete<P extends never, ApiSuccess, ApiError = any>(
+      req: { saga?: any },
+      fn: MiddlewareApiCo<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>,
+    ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
     delete<P, ApiSuccess, ApiError = any>(
       req: { saga?: any },
       fn: MiddlewareApiCo<Ctx>,
@@ -341,6 +391,9 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
     options<P>(req: {
       saga?: any;
     }): CreateActionWithPayload<Omit<Ctx, 'payload'> & Payload<P>, P>;
+    options<P extends never, ApiSuccess, ApiError = any>(req: {
+      saga?: any;
+    }): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
     options<P, ApiSuccess, ApiError = any>(req: {
       saga?: any;
     }): CreateActionWithPayload<
@@ -361,6 +414,9 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
     options<P, Gtx extends Ctx = Ctx>(
       fn: MiddlewareApiCo<Gtx>,
     ): CreateActionWithPayload<Gtx, P>;
+    options<P extends never, ApiSuccess, ApiError = any>(
+      fn: MiddlewareApiCo<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>,
+    ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
     options<P, ApiSuccess, ApiError = any>(
       fn: MiddlewareApiCo<Ctx>,
     ): CreateActionWithPayload<
@@ -386,6 +442,10 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
       req: { saga?: any },
       fn: MiddlewareApiCo<Gtx>,
     ): CreateActionWithPayload<Gtx, P>;
+    options<P extends never, ApiSuccess, ApiError = any>(
+      req: { saga?: any },
+      fn: MiddlewareApiCo<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>,
+    ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
     options<P, ApiSuccess, ApiError = any>(
       req: { saga?: any },
       fn: MiddlewareApiCo<Ctx>,
@@ -403,6 +463,9 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
     head<P>(req: {
       saga?: any;
     }): CreateActionWithPayload<Omit<Ctx, 'payload'> & Payload<P>, P>;
+    head<P extends never, ApiSuccess, ApiError = any>(req: {
+      saga?: any;
+    }): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
     head<P, ApiSuccess, ApiError = any>(req: {
       saga?: any;
     }): CreateActionWithPayload<
@@ -423,6 +486,9 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
     head<P, Gtx extends Ctx = Ctx>(
       fn: MiddlewareApiCo<Gtx>,
     ): CreateActionWithPayload<Gtx, P>;
+    head<P extends never, ApiSuccess, ApiError = any>(
+      fn: MiddlewareApiCo<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>,
+    ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
     head<P, ApiSuccess, ApiError = any>(
       fn: MiddlewareApiCo<Ctx>,
     ): CreateActionWithPayload<
@@ -448,6 +514,10 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
       req: { saga?: any },
       fn: MiddlewareApiCo<Gtx>,
     ): CreateActionWithPayload<Gtx, P>;
+    head<P extends never, ApiSuccess, ApiError = any>(
+      req: { saga?: any },
+      fn: MiddlewareApiCo<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>,
+    ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
     head<P, ApiSuccess, ApiError = any>(
       req: { saga?: any },
       fn: MiddlewareApiCo<Ctx>,
@@ -465,6 +535,9 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
     connect<P>(req: {
       saga?: any;
     }): CreateActionWithPayload<Omit<Ctx, 'payload'> & Payload<P>, P>;
+    connect<P extends never, ApiSuccess, ApiError = any>(req: {
+      saga?: any;
+    }): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
     connect<P, ApiSuccess, ApiError = any>(req: {
       saga?: any;
     }): CreateActionWithPayload<
@@ -485,6 +558,9 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
     connect<P, Gtx extends Ctx = Ctx>(
       fn: MiddlewareApiCo<Gtx>,
     ): CreateActionWithPayload<Gtx, P>;
+    connect<P extends never, ApiSuccess, ApiError = any>(
+      fn: MiddlewareApiCo<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>,
+    ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
     connect<P, ApiSuccess, ApiError = any>(
       fn: MiddlewareApiCo<Ctx>,
     ): CreateActionWithPayload<
@@ -510,6 +586,10 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
       req: { saga?: any },
       fn: MiddlewareApiCo<Gtx>,
     ): CreateActionWithPayload<Gtx, P>;
+    connect<P extends never, ApiSuccess, ApiError = any>(
+      req: { saga?: any },
+      fn: MiddlewareApiCo<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>,
+    ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
     connect<P, ApiSuccess, ApiError = any>(
       req: { saga?: any },
       fn: MiddlewareApiCo<Ctx>,
@@ -527,6 +607,9 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
     trace<P>(req: {
       saga?: any;
     }): CreateActionWithPayload<Omit<Ctx, 'payload'> & Payload<P>, P>;
+    trace<P extends never, ApiSuccess, ApiError = any>(req: {
+      saga?: any;
+    }): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
     trace<P, ApiSuccess, ApiError = any>(req: {
       saga?: any;
     }): CreateActionWithPayload<
@@ -547,6 +630,9 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
     trace<P, Gtx extends Ctx = Ctx>(
       fn: MiddlewareApiCo<Gtx>,
     ): CreateActionWithPayload<Gtx, P>;
+    trace<P extends never, ApiSuccess, ApiError = any>(
+      fn: MiddlewareApiCo<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>,
+    ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
     trace<P, ApiSuccess, ApiError = any>(
       fn: MiddlewareApiCo<Ctx>,
     ): CreateActionWithPayload<
@@ -572,6 +658,10 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
       req: { saga?: any },
       fn: MiddlewareApiCo<Gtx>,
     ): CreateActionWithPayload<Gtx, P>;
+    trace<P extends never, ApiSuccess, ApiError = any>(
+      req: { saga?: any },
+      fn: MiddlewareApiCo<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>,
+    ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
     trace<P, ApiSuccess, ApiError = any>(
       req: { saga?: any },
       fn: MiddlewareApiCo<Ctx>,
@@ -590,6 +680,9 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
   get<P>(
     name: ApiName,
   ): CreateActionWithPayload<Omit<Ctx, 'payload'> & Payload<P>, P>;
+  get<P extends never, ApiSuccess, ApiError = any>(
+    name: ApiName,
+  ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
   get<P, ApiSuccess, ApiError = any>(
     name: ApiName,
   ): CreateActionWithPayload<
@@ -611,6 +704,10 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
     name: ApiName,
     req: { saga?: any },
   ): CreateActionWithPayload<Gtx, P>;
+  get<P extends never, ApiSuccess, ApiError = any>(
+    name: ApiName,
+    req: { saga?: any },
+  ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
   get<P, ApiSuccess, ApiError = any>(
     name: ApiName,
     req: { saga?: any },
@@ -637,6 +734,10 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
     name: ApiName,
     fn: MiddlewareApiCo<Gtx>,
   ): CreateActionWithPayload<Gtx, P>;
+  get<P extends never, ApiSuccess, ApiError = any>(
+    name: ApiName,
+    fn: MiddlewareApiCo<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>,
+  ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
   get<P, ApiSuccess, ApiError = any>(
     name: ApiName,
     fn: MiddlewareApiCo<
@@ -674,6 +775,11 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
     req: { saga?: any },
     fn: MiddlewareApiCo<Gtx>,
   ): CreateActionWithPayload<Gtx, P>;
+  get<P extends never, ApiSuccess, ApiError = any>(
+    name: ApiName,
+    req: { saga?: any },
+    fn: MiddlewareApiCo<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>,
+  ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
   get<P, ApiSuccess, ApiError = any>(
     name: ApiName,
     req: { saga?: any },
@@ -696,6 +802,9 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
   post<P>(
     name: ApiName,
   ): CreateActionWithPayload<Omit<Ctx, 'payload'> & Payload<P>, P>;
+  post<P extends never, ApiSuccess, ApiError = any>(
+    name: ApiName,
+  ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
   post<P, ApiSuccess, ApiError = any>(
     name: ApiName,
   ): CreateActionWithPayload<
@@ -717,6 +826,10 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
     name: ApiName,
     req: { saga?: any },
   ): CreateActionWithPayload<Gtx, P>;
+  post<P extends never, ApiSuccess, ApiError = any>(
+    name: ApiName,
+    req: { saga?: any },
+  ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
   post<P, ApiSuccess, ApiError = any>(
     name: ApiName,
     req: { saga?: any },
@@ -743,6 +856,10 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
     name: ApiName,
     fn: MiddlewareApiCo<Gtx>,
   ): CreateActionWithPayload<Gtx, P>;
+  post<P extends never, ApiSuccess, ApiError = any>(
+    name: ApiName,
+    fn: MiddlewareApiCo<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>,
+  ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
   post<P, ApiSuccess, ApiError = any>(
     name: ApiName,
     fn: MiddlewareApiCo<
@@ -780,6 +897,11 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
     req: { saga?: any },
     fn: MiddlewareApiCo<Gtx>,
   ): CreateActionWithPayload<Gtx, P>;
+  post<P extends never, ApiSuccess, ApiError = any>(
+    name: ApiName,
+    req: { saga?: any },
+    fn: MiddlewareApiCo<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>,
+  ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
   post<P, ApiSuccess, ApiError = any>(
     name: ApiName,
     req: { saga?: any },
@@ -802,6 +924,9 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
   put<P>(
     name: ApiName,
   ): CreateActionWithPayload<Omit<Ctx, 'payload'> & Payload<P>, P>;
+  put<P extends never, ApiSuccess, ApiError = any>(
+    name: ApiName,
+  ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
   put<P, ApiSuccess, ApiError = any>(
     name: ApiName,
   ): CreateActionWithPayload<
@@ -823,6 +948,10 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
     name: ApiName,
     req: { saga?: any },
   ): CreateActionWithPayload<Gtx, P>;
+  put<P extends never, ApiSuccess, ApiError = any>(
+    name: ApiName,
+    req: { saga?: any },
+  ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
   put<P, ApiSuccess, ApiError = any>(
     name: ApiName,
     req: { saga?: any },
@@ -849,6 +978,10 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
     name: ApiName,
     fn: MiddlewareApiCo<Gtx>,
   ): CreateActionWithPayload<Gtx, P>;
+  put<P extends never, ApiSuccess, ApiError = any>(
+    name: ApiName,
+    fn: MiddlewareApiCo<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>,
+  ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
   put<P, ApiSuccess, ApiError = any>(
     name: ApiName,
     fn: MiddlewareApiCo<
@@ -886,6 +1019,11 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
     req: { saga?: any },
     fn: MiddlewareApiCo<Gtx>,
   ): CreateActionWithPayload<Gtx, P>;
+  put<P extends never, ApiSuccess, ApiError = any>(
+    name: ApiName,
+    req: { saga?: any },
+    fn: MiddlewareApiCo<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>,
+  ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
   put<P, ApiSuccess, ApiError = any>(
     name: ApiName,
     req: { saga?: any },
@@ -908,6 +1046,9 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
   patch<P>(
     name: ApiName,
   ): CreateActionWithPayload<Omit<Ctx, 'payload'> & Payload<P>, P>;
+  patch<P extends never, ApiSuccess, ApiError = any>(
+    name: ApiName,
+  ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
   patch<P, ApiSuccess, ApiError = any>(
     name: ApiName,
   ): CreateActionWithPayload<
@@ -929,6 +1070,10 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
     name: ApiName,
     req: { saga?: any },
   ): CreateActionWithPayload<Gtx, P>;
+  patch<P extends never, ApiSuccess, ApiError = any>(
+    name: ApiName,
+    req: { saga?: any },
+  ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
   patch<P, ApiSuccess, ApiError = any>(
     name: ApiName,
     req: { saga?: any },
@@ -955,6 +1100,10 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
     name: ApiName,
     fn: MiddlewareApiCo<Gtx>,
   ): CreateActionWithPayload<Gtx, P>;
+  patch<P extends never, ApiSuccess, ApiError = any>(
+    name: ApiName,
+    fn: MiddlewareApiCo<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>,
+  ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
   patch<P, ApiSuccess, ApiError = any>(
     name: ApiName,
     fn: MiddlewareApiCo<
@@ -992,6 +1141,11 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
     req: { saga?: any },
     fn: MiddlewareApiCo<Gtx>,
   ): CreateActionWithPayload<Gtx, P>;
+  patch<P extends never, ApiSuccess, ApiError = any>(
+    name: ApiName,
+    req: { saga?: any },
+    fn: MiddlewareApiCo<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>,
+  ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
   patch<P, ApiSuccess, ApiError = any>(
     name: ApiName,
     req: { saga?: any },
@@ -1014,6 +1168,9 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
   delete<P>(
     name: ApiName,
   ): CreateActionWithPayload<Omit<Ctx, 'payload'> & Payload<P>, P>;
+  delete<P extends never, ApiSuccess, ApiError = any>(
+    name: ApiName,
+  ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
   delete<P, ApiSuccess, ApiError = any>(
     name: ApiName,
   ): CreateActionWithPayload<
@@ -1035,6 +1192,10 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
     name: ApiName,
     req: { saga?: any },
   ): CreateActionWithPayload<Gtx, P>;
+  delete<P extends never, ApiSuccess, ApiError = any>(
+    name: ApiName,
+    req: { saga?: any },
+  ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
   delete<P, ApiSuccess, ApiError = any>(
     name: ApiName,
     req: { saga?: any },
@@ -1061,6 +1222,10 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
     name: ApiName,
     fn: MiddlewareApiCo<Gtx>,
   ): CreateActionWithPayload<Gtx, P>;
+  delete<P extends never, ApiSuccess, ApiError = any>(
+    name: ApiName,
+    fn: MiddlewareApiCo<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>,
+  ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
   delete<P, ApiSuccess, ApiError = any>(
     name: ApiName,
     fn: MiddlewareApiCo<
@@ -1098,6 +1263,11 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
     req: { saga?: any },
     fn: MiddlewareApiCo<Gtx>,
   ): CreateActionWithPayload<Gtx, P>;
+  delete<P extends never, ApiSuccess, ApiError = any>(
+    name: ApiName,
+    req: { saga?: any },
+    fn: MiddlewareApiCo<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>,
+  ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
   delete<P, ApiSuccess, ApiError = any>(
     name: ApiName,
     req: { saga?: any },
@@ -1120,6 +1290,9 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
   options<P>(
     name: ApiName,
   ): CreateActionWithPayload<Omit<Ctx, 'payload'> & Payload<P>, P>;
+  options<P extends never, ApiSuccess, ApiError = any>(
+    name: ApiName,
+  ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
   options<P, ApiSuccess, ApiError = any>(
     name: ApiName,
   ): CreateActionWithPayload<
@@ -1141,6 +1314,10 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
     name: ApiName,
     req: { saga?: any },
   ): CreateActionWithPayload<Gtx, P>;
+  options<P extends never, ApiSuccess, ApiError = any>(
+    name: ApiName,
+    req: { saga?: any },
+  ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
   options<P, ApiSuccess, ApiError = any>(
     name: ApiName,
     req: { saga?: any },
@@ -1167,6 +1344,10 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
     name: ApiName,
     fn: MiddlewareApiCo<Gtx>,
   ): CreateActionWithPayload<Gtx, P>;
+  options<P extends never, ApiSuccess, ApiError = any>(
+    name: ApiName,
+    fn: MiddlewareApiCo<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>,
+  ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
   options<P, ApiSuccess, ApiError = any>(
     name: ApiName,
     fn: MiddlewareApiCo<
@@ -1204,6 +1385,11 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
     req: { saga?: any },
     fn: MiddlewareApiCo<Gtx>,
   ): CreateActionWithPayload<Gtx, P>;
+  options<P extends never, ApiSuccess, ApiError = any>(
+    name: ApiName,
+    req: { saga?: any },
+    fn: MiddlewareApiCo<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>,
+  ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
   options<P, ApiSuccess, ApiError = any>(
     name: ApiName,
     req: { saga?: any },
@@ -1226,6 +1412,9 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
   head<P>(
     name: ApiName,
   ): CreateActionWithPayload<Omit<Ctx, 'payload'> & Payload<P>, P>;
+  head<P extends never, ApiSuccess, ApiError = any>(
+    name: ApiName,
+  ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
   head<P, ApiSuccess, ApiError = any>(
     name: ApiName,
   ): CreateActionWithPayload<
@@ -1247,6 +1436,10 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
     name: ApiName,
     req: { saga?: any },
   ): CreateActionWithPayload<Gtx, P>;
+  head<P extends never, ApiSuccess, ApiError = any>(
+    name: ApiName,
+    req: { saga?: any },
+  ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
   head<P, ApiSuccess, ApiError = any>(
     name: ApiName,
     req: { saga?: any },
@@ -1273,6 +1466,10 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
     name: ApiName,
     fn: MiddlewareApiCo<Gtx>,
   ): CreateActionWithPayload<Gtx, P>;
+  head<P extends never, ApiSuccess, ApiError = any>(
+    name: ApiName,
+    fn: MiddlewareApiCo<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>,
+  ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
   head<P, ApiSuccess, ApiError = any>(
     name: ApiName,
     fn: MiddlewareApiCo<
@@ -1310,6 +1507,11 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
     req: { saga?: any },
     fn: MiddlewareApiCo<Gtx>,
   ): CreateActionWithPayload<Gtx, P>;
+  head<P extends never, ApiSuccess, ApiError = any>(
+    name: ApiName,
+    req: { saga?: any },
+    fn: MiddlewareApiCo<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>,
+  ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
   head<P, ApiSuccess, ApiError = any>(
     name: ApiName,
     req: { saga?: any },
@@ -1332,6 +1534,9 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
   connect<P>(
     name: ApiName,
   ): CreateActionWithPayload<Omit<Ctx, 'payload'> & Payload<P>, P>;
+  connect<P extends never, ApiSuccess, ApiError = any>(
+    name: ApiName,
+  ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
   connect<P, ApiSuccess, ApiError = any>(
     name: ApiName,
   ): CreateActionWithPayload<
@@ -1353,6 +1558,10 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
     name: ApiName,
     req: { saga?: any },
   ): CreateActionWithPayload<Gtx, P>;
+  connect<P extends never, ApiSuccess, ApiError = any>(
+    name: ApiName,
+    req: { saga?: any },
+  ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
   connect<P, ApiSuccess, ApiError = any>(
     name: ApiName,
     req: { saga?: any },
@@ -1379,6 +1588,10 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
     name: ApiName,
     fn: MiddlewareApiCo<Gtx>,
   ): CreateActionWithPayload<Gtx, P>;
+  connect<P extends never, ApiSuccess, ApiError = any>(
+    name: ApiName,
+    fn: MiddlewareApiCo<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>,
+  ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
   connect<P, ApiSuccess, ApiError = any>(
     name: ApiName,
     fn: MiddlewareApiCo<
@@ -1416,6 +1629,11 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
     req: { saga?: any },
     fn: MiddlewareApiCo<Gtx>,
   ): CreateActionWithPayload<Gtx, P>;
+  connect<P extends never, ApiSuccess, ApiError = any>(
+    name: ApiName,
+    req: { saga?: any },
+    fn: MiddlewareApiCo<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>,
+  ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
   connect<P, ApiSuccess, ApiError = any>(
     name: ApiName,
     req: { saga?: any },
@@ -1438,6 +1656,9 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
   trace<P>(
     name: ApiName,
   ): CreateActionWithPayload<Omit<Ctx, 'payload'> & Payload<P>, P>;
+  trace<P extends never, ApiSuccess, ApiError = any>(
+    name: ApiName,
+  ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
   trace<P, ApiSuccess, ApiError = any>(
     name: ApiName,
   ): CreateActionWithPayload<
@@ -1459,6 +1680,10 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
     name: ApiName,
     req: { saga?: any },
   ): CreateActionWithPayload<Gtx, P>;
+  trace<P extends never, ApiSuccess, ApiError = any>(
+    name: ApiName,
+    req: { saga?: any },
+  ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
   trace<P, ApiSuccess, ApiError = any>(
     name: ApiName,
     req: { saga?: any },
@@ -1485,6 +1710,10 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
     name: ApiName,
     fn: MiddlewareApiCo<Gtx>,
   ): CreateActionWithPayload<Gtx, P>;
+  trace<P extends never, ApiSuccess, ApiError = any>(
+    name: ApiName,
+    fn: MiddlewareApiCo<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>,
+  ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
   trace<P, ApiSuccess, ApiError = any>(
     name: ApiName,
     fn: MiddlewareApiCo<
@@ -1522,6 +1751,11 @@ export interface SagaQueryApi<Ctx extends ApiCtx = ApiCtx>
     req: { saga?: any },
     fn: MiddlewareApiCo<Gtx>,
   ): CreateActionWithPayload<Gtx, P>;
+  trace<P extends never, ApiSuccess, ApiError = any>(
+    name: ApiName,
+    req: { saga?: any },
+    fn: MiddlewareApiCo<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>,
+  ): CreateAction<Omit<Ctx, 'json'> & FetchJson<ApiSuccess, ApiError>>;
   trace<P, ApiSuccess, ApiError = any>(
     name: ApiName,
     req: { saga?: any },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export { BATCH, batchActions } from 'redux-batched-actions';
-export * from 'redux-saga/effects';
 export type { SagaIterator } from 'redux-saga';
+export * from 'typed-redux-saga';
 
 export * from './pipe';
 export * from './api';

--- a/src/pipe.test.ts
+++ b/src/pipe.test.ts
@@ -1,6 +1,6 @@
 import test from 'ava';
 import type { SagaIterator } from 'redux-saga';
-import { put, call, delay } from 'redux-saga/effects';
+import { put, call, delay } from 'typed-redux-saga';
 import { createTable, createReducerMap } from 'robodux';
 import type { Action, MapEntity } from 'robodux';
 
@@ -196,7 +196,7 @@ test('error handling', (t) => {
   t.plan(1);
   const api = createPipe<RoboCtx>();
   api.use(api.routes());
-  api.use(function* upstream(ctx, next) {
+  api.use(function* upstream(_, next) {
     try {
       yield next();
     } catch (err) {
@@ -220,7 +220,7 @@ test('error handling inside create', (t) => {
     throw new Error('some error');
   });
 
-  const action = api.create(`/error`, function* (ctx, next) {
+  const action = api.create(`/error`, function* (_, next) {
     try {
       yield next();
     } catch (err) {
@@ -288,9 +288,9 @@ test('run() on endpoint action - should run the effect', (t) => {
   });
   const action2 = api.create(
     '/users2',
-    function* (ctx, next): SagaIterator<void> {
+    function* (_, next): SagaIterator<void> {
       yield next();
-      const curCtx = yield call(action1.run, action1());
+      const curCtx = yield* call(action1.run, action1());
       acc += 'b';
       t.assert(acc === 'ab');
       t.like(curCtx, {
@@ -316,7 +316,7 @@ test('middleware order of execution', async (t) => {
   const api = createPipe();
   api.use(api.routes());
 
-  api.use(function* (ctx, next) {
+  api.use(function* (_, next) {
     yield delay(10);
     acc += 'b';
     yield next();
@@ -324,7 +324,7 @@ test('middleware order of execution', async (t) => {
     acc += 'f';
   });
 
-  api.use(function* (ctx, next) {
+  api.use(function* (_, next) {
     acc += 'c';
     yield next();
     acc += 'd';
@@ -332,7 +332,7 @@ test('middleware order of execution', async (t) => {
     acc += 'e';
   });
 
-  const action = api.create('/api', function* (ctx, next) {
+  const action = api.create('/api', function* (_, next) {
     acc += 'a';
     yield next();
     acc += 'g';
@@ -384,7 +384,7 @@ test('retry with actionFn with payload', async (t) => {
     }
   });
 
-  const action = api.create<{ page: number }>('/api', function* (ctx, next) {
+  const action = api.create<{ page: number }>('/api', function* (_, next) {
     acc += 'a';
     yield next();
     acc += 'g';

--- a/src/types.ts
+++ b/src/types.ts
@@ -102,12 +102,17 @@ export interface CreateActionPayload<P = any> {
   options: P;
 }
 
-export interface CreateAction<Ctx> {
-  (): ActionWithPayload<CreateActionPayload<{}>>;
+export type CreateActionFn = () => ActionWithPayload<CreateActionPayload<{}>>;
+
+export interface CreateAction<Ctx> extends CreateActionFn {
   run: (p: ActionWithPayload<CreateActionPayload<{}>>) => SagaIterator<Ctx>;
 }
 
-export interface CreateActionWithPayload<Ctx, P> {
-  (p: P): ActionWithPayload<CreateActionPayload<P>>;
+export type CreateActionFnWithPayload<P = any> = (
+  p: P,
+) => ActionWithPayload<CreateActionPayload<P>>;
+
+export interface CreateActionWithPayload<Ctx, P>
+  extends CreateActionFnWithPayload<P> {
   run: (a: ActionWithPayload<CreateActionPayload<P>>) => SagaIterator<Ctx>;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,13 @@
 # yarn lockfile v1
 
 
+"@babel/code-frame@^7.0.0":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.18.6.tgz#3b25d38c89600baa2dcc219edfa88a74eb2c427a"
+  integrity sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==
+  dependencies:
+    "@babel/highlight" "^7.18.6"
+
 "@babel/code-frame@^7.10.4":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.16.7.tgz#44416b6bd7624b998f5b1af5d470856c40138789"
@@ -9,10 +16,27 @@
   dependencies:
     "@babel/highlight" "^7.16.7"
 
+"@babel/helper-module-imports@^7.14.5":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz#1e3ebdbbd08aad1437b428c50204db13c5a3ca6e"
+  integrity sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==
+  dependencies:
+    "@babel/types" "^7.18.6"
+
+"@babel/helper-string-parser@^7.19.4":
+  version "7.19.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz#38d3acb654b4701a9b77fb0615a96f775c3a9e63"
+  integrity sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==
+
 "@babel/helper-validator-identifier@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz#e8c602438c4a8195751243da9031d1607d247cad"
   integrity sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==
+
+"@babel/helper-validator-identifier@^7.18.6", "@babel/helper-validator-identifier@^7.19.1":
+  version "7.19.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz#7eea834cf32901ffdc1a7ee555e2f9c27e249ca2"
+  integrity sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==
 
 "@babel/highlight@^7.16.7":
   version "7.17.9"
@@ -20,6 +44,15 @@
   integrity sha512-J9PfEKCbFIv2X5bjTMiZu6Vf341N05QIY+d6FvVKynkG1S7G0j3I0QoRtWIrXhZ+/Nlb5Q0MzqL7TokEJ5BNHg==
   dependencies:
     "@babel/helper-validator-identifier" "^7.16.7"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
+
+"@babel/highlight@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.18.6.tgz#81158601e93e2563795adcbfbdf5d64be3f2ecdf"
+  integrity sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.18.6"
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
@@ -43,6 +76,15 @@
   integrity sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==
   dependencies:
     regenerator-runtime "^0.13.4"
+
+"@babel/types@^7.18.6":
+  version "7.20.7"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.20.7.tgz#54ec75e252318423fc07fb644dc6a58a64c09b7f"
+  integrity sha512-69OnhBxSSgK0OzTJai4kyPDiKTIe3j+ctaHdIGVbRahTLAT7L3R9oeXHC2aVSuGYt3cVnoAMDmOCgJ2yaiLMvg==
+  dependencies:
+    "@babel/helper-string-parser" "^7.19.4"
+    "@babel/helper-validator-identifier" "^7.19.1"
+    to-fast-properties "^2.0.0"
 
 "@cspotcode/source-map-consumer@0.8.0":
   version "0.8.0"
@@ -186,6 +228,11 @@
   version "17.0.23"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.23.tgz#3b41a6e643589ac6442bdbd7a4a3ded62f33f7da"
   integrity sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==
+
+"@types/parse-json@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
+  integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
 "@types/prettier@^2.7.2":
   version "2.7.2"
@@ -436,6 +483,15 @@ ava@^4.1.0:
     write-file-atomic "^4.0.1"
     yargs "^17.3.1"
 
+babel-plugin-macros@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz#9ef6dc74deb934b4db344dc973ee851d148c50c1"
+  integrity sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    cosmiconfig "^7.0.0"
+    resolve "^1.19.0"
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
@@ -470,6 +526,11 @@ browser-process-hrtime@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz#3c9b4b7d782c8121e56f10106d84c0d0ffc94626"
   integrity sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==
+
+callsites@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
+  integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
 callsites@^4.0.0:
   version "4.0.0"
@@ -661,6 +722,17 @@ convert-to-spaces@^2.0.1:
   resolved "https://registry.yarnpkg.com/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz#61a6c98f8aa626c16b296b862a91412a33bceb6b"
   integrity sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==
 
+cosmiconfig@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.1.0.tgz#1443b9afa596b670082ea46cbd8f6a62b84635f6"
+  integrity sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==
+  dependencies:
+    "@types/parse-json" "^4.0.0"
+    import-fresh "^3.2.1"
+    parse-json "^5.0.0"
+    path-type "^4.0.0"
+    yaml "^1.10.0"
+
 create-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
@@ -814,6 +886,13 @@ emoji-regex@^9.2.2:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
   integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
 
+error-ex@^1.3.1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
+  integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
+  dependencies:
+    is-arrayish "^0.2.1"
+
 escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
@@ -958,6 +1037,11 @@ fsevents@~2.3.2:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
+function-bind@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
+  integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
+
 get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
@@ -1030,6 +1114,13 @@ has-flag@^4.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
+has@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
+  integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
+  dependencies:
+    function-bind "^1.1.1"
+
 hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
@@ -1098,6 +1189,14 @@ immer@^9.0.7:
   resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.12.tgz#2d33ddf3ee1d247deab9d707ca472c8c942a0f20"
   integrity sha512-lk7UNmSbAukB5B6dh9fnh5D0bJTOFKxVg2cyJWTYrWRfhLrLMBquONcUs3aFq507hNoIZEDDh8lb8UtOizSMhA==
 
+import-fresh@^3.2.1:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
+  integrity sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==
+  dependencies:
+    parent-module "^1.0.0"
+    resolve-from "^4.0.0"
+
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
@@ -1131,12 +1230,24 @@ irregular-plurals@^3.3.0:
   resolved "https://registry.yarnpkg.com/irregular-plurals/-/irregular-plurals-3.3.0.tgz#67d0715d4361a60d9fd9ee80af3881c631a31ee2"
   integrity sha512-MVBLKUTangM3EfRPFROhmWQQKRDsrgI83J8GS3jXy+OwYqiR2/aoWndYQ5416jLE3uaGgLH7ncme3X9y09gZ3g==
 
+is-arrayish@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
+  integrity sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==
+
 is-binary-path@~2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
   integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
   dependencies:
     binary-extensions "^2.0.0"
+
+is-core-module@^2.9.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.11.0.tgz#ad4cb3e3863e814523c96f3f58d26cc570ff0144"
+  integrity sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==
+  dependencies:
+    has "^1.0.3"
 
 is-error@^2.2.2:
   version "2.2.2"
@@ -1261,6 +1372,11 @@ jsdom@^19.0.0:
     ws "^8.2.3"
     xml-name-validator "^4.0.0"
 
+json-parse-even-better-errors@^2.3.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
+  integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
+
 json-stringify-safe@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
@@ -1278,6 +1394,11 @@ lilconfig@2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-2.0.4.tgz#f4507d043d7058b380b6a8f5cb7bcd4b34cee082"
   integrity sha512-bfTIN7lEsiooCocSISTWXkiWJkRqtL9wYtYy+8EK3Y41qh3mpwPU0ycTOgjdY9ErwXCc8QyrQp82bdL0Xkm9yA==
+
+lines-and-columns@^1.1.6:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
+  integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
 lint-staged@^12.3.7:
   version "12.3.7"
@@ -1570,6 +1691,23 @@ p-timeout@^5.0.2:
   resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-5.0.2.tgz#d12964c4b2f988e15f72b455c2c428d82a0ec0a0"
   integrity sha512-sEmji9Yaq+Tw+STwsGAE56hf7gMy9p0tQfJojIAamB7WHJYJKf1qlsg9jqBWG8q9VCxKPhZaP/AcXwEoBcYQhQ==
 
+parent-module@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
+  integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
+  dependencies:
+    callsites "^3.0.0"
+
+parse-json@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.2.0.tgz#c76fc66dee54231c962b22bcc8a72cf2f99753cd"
+  integrity sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    error-ex "^1.3.1"
+    json-parse-even-better-errors "^2.3.0"
+    lines-and-columns "^1.1.6"
+
 parse-ms@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/parse-ms/-/parse-ms-2.1.0.tgz#348565a753d4391fa524029956b172cb7753097d"
@@ -1594,6 +1732,11 @@ path-key@^3.0.0, path-key@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
+
+path-parse@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
+  integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
 path-type@^4.0.0:
   version "4.0.0"
@@ -1773,10 +1916,24 @@ resolve-cwd@^3.0.0:
   dependencies:
     resolve-from "^5.0.0"
 
+resolve-from@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
+  integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
+
 resolve-from@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
+
+resolve@^1.19.0:
+  version "1.22.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
+  integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
+  dependencies:
+    is-core-module "^2.9.0"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
 
 restore-cursor@^3.1.0:
   version "3.1.0"
@@ -2020,6 +2177,11 @@ supports-color@^9.2.1:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-9.2.2.tgz#502acaf82f2b7ee78eb7c83dcac0f89694e5a7bb"
   integrity sha512-XC6g/Kgux+rJXmwokjm9ECpD6k/smUoS5LKlUCcsYr4IY3rW0XyAympon2RmxGrlnZURMpg5T18gWDP9CsHXFA==
 
+supports-preserve-symlinks-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
+  integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
+
 symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
@@ -2039,6 +2201,11 @@ time-zone@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/time-zone/-/time-zone-1.0.0.tgz#99c5bf55958966af6d06d83bdf3800dc82faec5d"
   integrity sha1-mcW/VZWJZq9tBtg73zgA3IL67F0=
+
+to-fast-properties@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
+  integrity sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==
 
 to-regex-range@^5.0.1:
   version "5.0.1"
@@ -2108,6 +2275,14 @@ type-fest@^0.21.3:
   version "0.21.3"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
+
+typed-redux-saga@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/typed-redux-saga/-/typed-redux-saga-1.5.0.tgz#f70b47c92c6e29e0184d0c30d563c18d6ad0ae54"
+  integrity sha512-XHKliNtRNUegYAAztbVDb5Q+FMqYNQPaed6Xq2N8kz8AOmiOCVxW3uIj7TEptR1/ms6M9u3HEDfJr4qqz/PYrw==
+  optionalDependencies:
+    "@babel/helper-module-imports" "^7.14.5"
+    babel-plugin-macros "^3.1.0"
 
 typescript-compare@^0.0.2:
   version "0.0.2"
@@ -2281,7 +2456,7 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yaml@^1.10.2:
+yaml@^1.10.0, yaml@^1.10.2:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==


### PR DESCRIPTION
BREAKING CHANGE: importing saga effects from `saga-query` will require `yield *` now