### PR TITLE
Add conditional parameter to fetchRetry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist
 *.bak
 .envrc
 .direnv/
+
 # Ignore yarn lock files
 yarn.lock
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ dist
 *.bak
 .envrc
 .direnv/
+# Ignore yarn lock files
+yarn.lock
+
+# Ignore npm lock files
+package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ yarn.lock
 
 # Ignore npm lock files
 package-lock.json
+
+# Ignore tar files
+*.tgz

--- a/src/fetch.test.ts
+++ b/src/fetch.test.ts
@@ -374,7 +374,7 @@ test('fetch retry conditional - conditional retry', async (t) => {
   nock(baseUrl).get('/users').reply(200, mockUserNotVerif);
   nock(baseUrl).get('/users').reply(200, mockUserVerif);
 
-  const waitTime = 30;
+  const waitTime = 20;
   const attemtps = 5;
 
   const api = createApi();

--- a/src/fetch.test.ts
+++ b/src/fetch.test.ts
@@ -374,7 +374,7 @@ test('fetch retry conditional - conditional retry', async (t) => {
   nock(baseUrl).get('/users').reply(200, mockUserNotVerif);
   nock(baseUrl).get('/users').reply(200, mockUserVerif);
 
-  const waitTime = 20;
+  const waitTime = 10;
   const attemtps = 5;
 
   const api = createApi();

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -151,7 +151,7 @@ function backoffExp(attempt: number): number {
 }
 
 function responseOkCond(ctx: FetchJsonCtx): boolean {
-  return ctx.json.ok;
+  return !!ctx.response?.ok;
 }
 /**
  * This middleware will retry any fetch if condition is not met, or by default the failed `Fetch` request if `response.ok` is `false`.
@@ -171,11 +171,10 @@ function responseOkCond(ctx: FetchJsonCtx): boolean {
  *    if (attempt > 5) return -1;
  *    return 1000;
  *  }
- *
- * An example cond:
- * @example
- * ```ts
- * // Retry if the emqil is not verified
+ *  // Retry until the email is verified . We set the pass condition:
+ *  const cond = (pctx: FetchJsonCtx) => {
+ *    return pctx.json?.data?.email_verified === true;
+ *  }
  *
  * const api = createApi();
  * api.use(requestMonitor());
@@ -189,7 +188,7 @@ function responseOkCond(ctx: FetchJsonCtx): boolean {
  *  },
  *  // fetchRetry should be after your endpoint function because
  *  // the retry middleware will update `ctx.json` before it reaches your middleware
- *  fetchRetry(backoff),
+ *  fetchRetry(backoff, cond)
  * ])
  * ```
  */


### PR DESCRIPTION
The motivation for this PR is given by the following factors:
In case of a server error, it is possible for the server to refuse retry on that endpoint.
In case a condition is expected, not necessarily of the nature of errors but of content.

This PR extends the existing fetchRetry functionality by making it more general, by adding a conditional function as a parameter. 
This is a non-breaking change.

This function has the default value to be checked, the previously defined expression. Now it becomes a parameter and has the signature:

`cond: (ctx: CurCtx) => boolean = responseOkCond,`

where the default value of the verification function is 
```ts
function responseOkCond(ctx: FetchJsonCtx): boolean {
  return !!ctx.response?.ok;
}
```
Therefore, the fetchRetry middleware becomes:
```ts
export function fetchRetry<CurCtx extends FetchJsonCtx = FetchJsonCtx>(
  backoff: (attempt: number) => number = backoffExp,
  cond: (ctx: CurCtx) => boolean = responseOkCond,
) {
 //...
}
```

As an example, we can have the situation of validating an email:
```ts
export const checkIfEmailIsVerified = api.get(
  "/email-verified",
  [function* (ctx: ApiCtx<any, unknown, any>, next): any {
    //..
    yield next();
    const { ok, data } = yield ctx.json;
    if (ok && data.email_verified === true) {
      yield* put(loginRepo.actions.set(data));
    }
  },
  fetchRetry(
    // let's try 10 times with 30 seconds delay
    (n)=> n < 10 ? 30000 : -1,
    (vCtx) => {
      return vCtx.json.data.email_verified === true
    },
  )
]
);
```

